### PR TITLE
Split 03system/item's Status into two separate bytes

### DIFF
--- a/KH2FM_Editor/Model/System03/Item/ItemItem.cs
+++ b/KH2FM_Editor/Model/System03/Item/ItemItem.cs
@@ -1,4 +1,4 @@
-﻿using KH2FM_Editor.DataDictionary;
+using KH2FM_Editor.DataDictionary;
 using KH2FM_Editor.Libs.Binary;
 using KH2FM_Editor.Libs.Utils;
 using KH2FM_Editor.Model.COMMON;
@@ -15,7 +15,8 @@ namespace KH2FM_Editor.Model.System03.Item
         public int visibilityOffset = 3, visibilitySize = 1;
         public int subIdOffset = 4, subIdSize = 1;
         public int rankOffset = 5, rankSize = 1;
-        public int statusOffset = 6, statusSize = 2;
+        public int statusWepOffset = 6, statusWepSize = 1;
+        public int statusOffset = 7, statusSize = 1;
         public int nameOffset = 8, nameSize = 2;
         public int descriptionOffset = 10, descriptionSize = 2;
         public int buyOffset = 12, buySize = 2;
@@ -71,10 +72,15 @@ namespace KH2FM_Editor.Model.System03.Item
             get { return DataAccess.readByte(raw, rankOffset); }
             set { DataAccess.writeByte(raw, value, rankOffset); }
         }
-        public ushort Status
+        public byte StatusWep
         {
-            get { return DataAccess.readUShort(raw, statusOffset, statusSize); }
-            set { DataAccess.writeUShort(raw, value, statusOffset, statusSize); }
+            get { return DataAccess.readByte(raw, statusWepOffset); }
+            set { DataAccess.writeByte(raw, value, statusWepOffset); }
+        }
+        public byte Status
+        {
+            get { return DataAccess.readByte(raw, statusOffset); }
+            set { DataAccess.writeByte(raw, value, statusOffset); }
         }
         public ushort Name
         {

--- a/KH2FM_Editor/Model/System03/Item/ItemItem.cs
+++ b/KH2FM_Editor/Model/System03/Item/ItemItem.cs
@@ -15,8 +15,8 @@ namespace KH2FM_Editor.Model.System03.Item
         public int visibilityOffset = 3, visibilitySize = 1;
         public int subIdOffset = 4, subIdSize = 1;
         public int rankOffset = 5, rankSize = 1;
-        public int statusWepOffset = 6, statusWepSize = 1;
-        public int statusOffset = 7, statusSize = 1;
+        public int statusOffset = 6, statusSize = 1;
+        public int apcostOffset = 7, apcostSize = 1;
         public int nameOffset = 8, nameSize = 2;
         public int descriptionOffset = 10, descriptionSize = 2;
         public int buyOffset = 12, buySize = 2;
@@ -72,15 +72,15 @@ namespace KH2FM_Editor.Model.System03.Item
             get { return DataAccess.readByte(raw, rankOffset); }
             set { DataAccess.writeByte(raw, value, rankOffset); }
         }
-        public byte StatusWep
-        {
-            get { return DataAccess.readByte(raw, statusWepOffset); }
-            set { DataAccess.writeByte(raw, value, statusWepOffset); }
-        }
         public byte Status
         {
             get { return DataAccess.readByte(raw, statusOffset); }
             set { DataAccess.writeByte(raw, value, statusOffset); }
+        }
+        public byte APCost
+        {
+            get { return DataAccess.readByte(raw, apcostOffset); }
+            set { DataAccess.writeByte(raw, value, apcostOffset); }
         }
         public ushort Name
         {

--- a/KH2FM_Editor/View/System03/Item/ItemPage.xaml
+++ b/KH2FM_Editor/View/System03/Item/ItemPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="KH2FM_Editor.View.System03.Item.ItemPage"
+<Page x:Class="KH2FM_Editor.View.System03.Item.ItemPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -37,6 +37,7 @@
                             <DataGridTextColumn Header="Visibility Id" Binding="{Binding Path=Visibility}" />
                             <DataGridTextColumn Header="SubId" Binding="{Binding Path=SubId}" />
                             <DataGridTextColumn Header="Rank" Binding="{Binding Path=Rank}" />
+                            <DataGridTextColumn Header="StatusWep" Binding="{Binding Path=StatusWep}" />
                             <DataGridTextColumn Header="Status" Binding="{Binding Path=Status}" />
                             <DataGridTextColumn Header="Name" Binding="{Binding Path=Name}" />
                             <DataGridTextColumn Header="Description" Binding="{Binding Path=Description}" />

--- a/KH2FM_Editor/View/System03/Item/ItemPage.xaml
+++ b/KH2FM_Editor/View/System03/Item/ItemPage.xaml
@@ -37,8 +37,8 @@
                             <DataGridTextColumn Header="Visibility Id" Binding="{Binding Path=Visibility}" />
                             <DataGridTextColumn Header="SubId" Binding="{Binding Path=SubId}" />
                             <DataGridTextColumn Header="Rank" Binding="{Binding Path=Rank}" />
-                            <DataGridTextColumn Header="StatusWep" Binding="{Binding Path=StatusWep}" />
                             <DataGridTextColumn Header="Status" Binding="{Binding Path=Status}" />
+                            <DataGridTextColumn Header="APCost" Binding="{Binding Path=APCost}" />
                             <DataGridTextColumn Header="Name" Binding="{Binding Path=Name}" />
                             <DataGridTextColumn Header="Description" Binding="{Binding Path=Description}" />
                             <DataGridTextColumn Header="Buy" Binding="{Binding Path=Buy}" />


### PR DESCRIPTION
Currently, in KH2FM_Editor, 03system.bin/item's Status variable is written as a short. However, Status is two separate bytes; one related to consumable items/weapons and the other being AP Cost. This PR splits them up, leaving "Status" for Consumable Item/Weapons and adding in APCost.